### PR TITLE
Adding new parameter to drive when to run JSCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ configuration options and the default values are as follows:
         compiled: true,
         copied: true,
         vendor: false,
-        executeOnCompiledCode: true,
+        executeAfterCompile: true,
         configFile: undefined,
         rules: {}
     }
@@ -35,7 +35,7 @@ Which files are linted are controlled by the `jscs.exclude`,
 options work just like the corresponding options for the
 [JSHint Mimosa plugin](https://github.com/dbashford/mimosa-jshint).
 
-`executeOnCompiledCode` determines whether JSCS runs on code before
+`executeAfterCompile` determines whether JSCS runs on code before
 or after it is compiled. This defaults to `true` which means that
 JSCS runs on compiled code. So, for instance, it would not run on
 CoffeeScript, instead it would run on the compiled JavaScript. You

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ configuration options and the default values are as follows:
         compiled: true,
         copied: true,
         vendor: false,
+        executeOnCompiledCode: true,
         configFile: undefined,
         rules: {}
     }
@@ -33,6 +34,15 @@ Which files are linted are controlled by the `jscs.exclude`,
 `jscs.compiled`, `jscs.copied`, and `jscs.vendor` options. These
 options work just like the corresponding options for the
 [JSHint Mimosa plugin](https://github.com/dbashford/mimosa-jshint).
+
+`executeOnCompiledCode` determines whether JSCS runs on code before
+or after it is compiled. This defaults to `true` which means that
+JSCS runs on compiled code. So, for instance, it would not run on
+CoffeeScript, instead it would run on the compiled JavaScript. You
+may find you want to run on pre-compiled code. Some compilers, like
+[Babel](http://www.babeljs.io) will transform the style of the code
+when it compiles it.  If running on the compiled output of Babel,
+JSCS will have many problems that cannot be avoided.
 
 To configure JSCS, set either the `jscs.rules` property, the
 `jscs.configFile` property, or both. JSCS configuration options are

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ exports.defaults = function () {
       compiled: true,
       copied: true,
       vendor: false,
-      executeOnCompiledCode: true
+      executeAfterCompile: true
     }
   };
 };
@@ -26,14 +26,14 @@ exports.validate = function (config, validators) {
   if (validators.ifExistsIsObject(errors, 'jscs config', config.jscs)) {
 
     if (validators.ifExistsIsBoolean(errors,
-                                     'jscs.executeOnCompiledCode',
-                                     config.jscs.executeOnCompiledCode)) {
+                                     'jscs.executeAfterCompile',
+                                     config.jscs.executeAfterCompile)) {
 
       // Determine what step to run JSCS at and what
       // text to run it on. Create specific function
       // to return value rather than run if stmt on
       // flag for each file.
-      if (config.jscs.executeOnCompiledCode) {
+      if (config.jscs.executeAfterCompile) {
         config.jscs.workflowStep = 'afterCompile';
         config.jscs.textToProcess = function(file) {
           return file.outputFileText;

--- a/src/config.js
+++ b/src/config.js
@@ -12,7 +12,8 @@ exports.defaults = function () {
       exclude: [],
       compiled: true,
       copied: true,
-      vendor: false
+      vendor: false,
+      executeOnCompiledCode: true
     }
   };
 };
@@ -23,6 +24,28 @@ exports.validate = function (config, validators) {
   var errors = [];
 
   if (validators.ifExistsIsObject(errors, 'jscs config', config.jscs)) {
+
+    if (validators.ifExistsIsBoolean(errors,
+                                     'jscs.executeOnCompiledCode',
+                                     config.jscs.executeOnCompiledCode)) {
+
+      // Determine what step to run JSCS at and what
+      // text to run it on. Create specific function
+      // to return value rather than run if stmt on
+      // flag for each file.
+      if (config.jscs.executeOnCompiledCode) {
+        config.jscs.workflowStep = 'afterCompile';
+        config.jscs.textToProcess = function(file) {
+          return file.outputFileText;
+        };
+      } else {
+        config.jscs.workflowStep = 'beforeCompile';
+        config.jscs.textToProcess = function(file) {
+          return file.inputFileText;
+        };
+      }
+    }
+
     // Note: Call below will modify config to have an
     // jscs.excludeRegex and change jscs.exclude to have absolute
     // paths

--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,11 @@ function registration (mimosaConfig, register) {
   var extensions = getFileExtensions(mimosaConfig);
   if (extensions.length > 0) {
     register(['buildFile'],
-             'afterCompile',
+             mimosaConfig.jscs.workflowStep,
              onMimosaBuildWorkflowCallback,
              extensions);
     register(['add', 'update'],
-             'afterCompile',
+             mimosaConfig.jscs.workflowStep,
              onMimosaWatchWorkflowCallback,
              extensions);
   }
@@ -140,7 +140,8 @@ function processFiles(mimosaConfig, files) {
  * configuration.
  */
 function shouldProcessFile(mimosaConfig, file) {
-  if (!file.outputFileText) {
+  var text = mimosaConfig.jscs.textToProcess(file);
+  if (!text) {
     return false;
   }
 
@@ -196,8 +197,8 @@ function isFileExcludedBasedOnName(moduleConfig, absolutePath, relativePath) {
  */
 function processFile(moduleConfig, file) {
   var jscs = loadJscs(moduleConfig);
-
-  var errors = checkString(jscs, file.outputFileText, file.inputFileName);
+  var text = moduleConfig.textToProcess(file);
+  var errors = checkString(jscs, text, file.inputFileName);
   errors.forEach(function (error) {
     logJscsError(file.inputFileName, error);
   });


### PR DESCRIPTION
1. Added `executeAfterConfig` boolean config parameter
2. Use parameter to determine what step to run JSCS at and whether to use input text or output text.
3. Updated README
